### PR TITLE
Fix joins for running stat views

### DIFF
--- a/prophesizer/migrations/R__1_Create_Functions.pgsql
+++ b/prophesizer/migrations/R__1_Create_Functions.pgsql
@@ -1,4 +1,4 @@
-﻿-- LAST UPDATE: 4/18/2021
+﻿-- LAST UPDATE: 4/21/2021
 
 DROP FUNCTION IF EXISTS data.reblase_gameeventid(in_game_event_id bigint) CASCADE;
 DROP FUNCTION IF EXISTS data.gamephase_from_timestamp(in_timestamp timestamp without time zone) CASCADE;

--- a/prophesizer/migrations/R__2_ Create_Procedures.pgsql
+++ b/prophesizer/migrations/R__2_ Create_Procedures.pgsql
@@ -1,4 +1,4 @@
-﻿-- LAST UPDATE: 4/18/2021
+﻿-- LAST UPDATE: 4/21/2021
  
 DROP PROCEDURE IF EXISTS data.wipe_hourly();
 DROP PROCEDURE IF EXISTS data.wipe_events();

--- a/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
+++ b/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
@@ -1,4 +1,4 @@
-﻿-- LAST UPDATE: 4/18/2021
+﻿-- LAST UPDATE: 4/21/2021
 
 DROP TABLE IF EXISTS taxa.weather CASCADE;
 DROP SEQUENCE IF EXISTS taxa.vibe_to_arrows_vibe_to_arrow_id_seq CASCADE;

--- a/prophesizer/migrations/R__4_Create_Views.pgsql
+++ b/prophesizer/migrations/R__4_Create_Views.pgsql
@@ -1,4 +1,4 @@
-﻿-- LAST UPDATE: 4/18/2021
+﻿-- LAST UPDATE: 4/21/2021
 
 DROP VIEW IF EXISTS DATA.ref_leaderboard_lifetime_batting CASCADE;
 DROP VIEW IF EXISTS DATA.ref_recordboard_player_season_batting CASCADE;
@@ -2957,7 +2957,7 @@ CREATE VIEW data.running_stats_player_season AS
     sum(rs.runner_scored) AS runs
    FROM ((data.running_stats_all_events rs
      JOIN data.players_info_expanded_all p ON ((((rs.player_id)::text = (p.player_id)::text) AND (p.valid_until IS NULL))))
-     LEFT JOIN data.teams_info_expanded_all t ON ((((p.team_id)::text = (t.team_id)::text) AND (t.valid_until IS NULL))))
+     LEFT JOIN data.teams_info_expanded_all t ON ((((rs.team_id)::text = (t.team_id)::text) AND (t.valid_until IS NULL))))
   WHERE ((rs.day < 99) AND (rs.season > 0))
   GROUP BY rs.player_id, rs.season, rs.team_id, t.nickname, t.valid_from, t.valid_until, p.player_name;
 
@@ -2965,31 +2965,31 @@ CREATE VIEW data.running_stats_player_season AS
 -- Name: running_stats_team_season; Type: VIEW; Schema: data; Owner: -
 --
 CREATE VIEW data.running_stats_team_season AS
- SELECT p.team,
-	p.team_id,
+ SELECT t.nickname AS team,
+	rs.team_id,
     rs.season,
     sum(rs.was_base_stolen) AS stolen_bases,
     sum(rs.was_caught_stealing) AS caught_stealing,
     sum(rs.runner_scored) AS runs
    FROM (data.running_stats_all_events rs
-     JOIN data.players_info_expanded_all p ON ((((rs.player_id)::text = (p.player_id)::text) AND (p.valid_until IS NULL))))
+     JOIN data.teams_info_expanded_all t ON (((rs.team_id)::text = (t.team_id)::text) AND (t.valid_until IS NULL)))
   WHERE ((rs.day < 99) AND (rs.season > 0))
-  GROUP BY p.team, p.team_id, rs.season;
+  GROUP BY rs.team_id, rs.season, team;
   
 --
 -- Name: running_stats_team_playoffs_season; Type: VIEW; Schema: data; Owner: -
 --
 CREATE VIEW data.running_stats_team_playoffs_season AS
- SELECT p.team,
-	p.team_id,
+ SELECT t.nickname AS team,
+	rs.team_id,
     rs.season,
     sum(rs.was_base_stolen) AS stolen_bases,
     sum(rs.was_caught_stealing) AS caught_stealing,
     sum(rs.runner_scored) AS runs
    FROM (data.running_stats_all_events rs
-     JOIN data.players_info_expanded_all p ON ((((rs.player_id)::text = (p.player_id)::text) AND (p.valid_until IS NULL))))
+     JOIN data.teams_info_expanded_all t ON (((rs.team_id)::text = (t.team_id)::text) AND (t.valid_until IS NULL)))
   WHERE ((rs.day >= 99) AND (rs.season > 0))
-  GROUP BY p.team, p.team_id, rs.season;
+  GROUP BY rs.team_id, rs.season, team;
 
 --
 -- Name: running_stats_player_playoffs_season; Type: VIEW; Schema: data; Owner: -
@@ -3008,7 +3008,7 @@ CREATE VIEW data.running_stats_player_playoffs_season AS
     sum(rs.runner_scored) AS runs
    FROM ((data.running_stats_all_events rs
      JOIN data.players_info_expanded_all p ON ((((rs.player_id)::text = (p.player_id)::text) AND (p.valid_until IS NULL))))
-     JOIN data.teams_info_expanded_all t ON ((((p.team_id)::text = (t.team_id)::text) AND (t.valid_until IS NULL))))
+     JOIN data.teams_info_expanded_all t ON ((((rs.team_id)::text = (t.team_id)::text) AND (t.valid_until IS NULL))))
   WHERE ((rs.day > 98) AND (rs.season > 0))
   GROUP BY rs.player_id, rs.season, rs.team_id, t.nickname, t.valid_from, t.valid_until, p.player_name;
   


### PR DESCRIPTION
This fixes running stats being incorrectly applied to a player's current
team as opposed to the team the player was on when the event occurred.

Thanks to Inferno390 for reporting the issue and to korvys for
identifying the cause.