### PR TITLE
Pre-history fixes, Cup shadows patch cleanup

### DIFF
--- a/prophesizer/migrations/R__1_Create_Functions.pgsql
+++ b/prophesizer/migrations/R__1_Create_Functions.pgsql
@@ -1,4 +1,4 @@
--- LAST UPDATE: 6/16/2021:
+-- LAST UPDATE: 6/25/2021:
 
 DROP FUNCTION IF EXISTS data.reblase_gameeventid(in_game_event_id bigint) CASCADE;
 DROP FUNCTION IF EXISTS data.gamephase_from_timestamp(in_timestamp timestamp without time zone) CASCADE;

--- a/prophesizer/migrations/R__1_Create_Functions.pgsql
+++ b/prophesizer/migrations/R__1_Create_Functions.pgsql
@@ -1,4 +1,5 @@
 -- LAST UPDATE: 6/25/2021:
+-- Update team url_slug function to specifically handle crabs-2 and artists-2
 
 DROP FUNCTION IF EXISTS data.reblase_gameeventid(in_game_event_id bigint) CASCADE;
 DROP FUNCTION IF EXISTS data.gamephase_from_timestamp(in_timestamp timestamp without time zone) CASCADE;
@@ -895,9 +896,20 @@ $$;
 CREATE FUNCTION data.team_slug_creation() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
-BEGIN
-	new.url_slug = replace(regexp_replace(lower(unaccent(replace(new.nickname,'&','and'))), '[^A-Za-z'' ]', '','g'),' ','-');
-	RETURN new;
+BEGIN	
+
+	UPDATE new
+	SET new.url_slug = 
+	   CASE NEW.team_id
+		WHEN '9494152b-99f6-4adb-9573-f9e084bc813f'
+		THEN 'crabs-2'
+		WHEN '3b0a289b-aebd-493c-bc11-96793e7216d5' 
+		THEN 'artists-2'
+		ELSE replace(regexp_replace(lower(unaccent(replace(new.nickname,'&','and'))), '[^A-Za-z'' ]', '','g'),' ','-')
+   END;
+
+RETURN NEW;
+
 END;
 $$;
 --

--- a/prophesizer/migrations/R__2_ Create_Procedures.pgsql
+++ b/prophesizer/migrations/R__2_ Create_Procedures.pgsql
@@ -1,4 +1,4 @@
--- LAST UPDATE: 6/25/2021
+-- LAST UPDATE: 6/28/2021x
  
 DROP PROCEDURE IF EXISTS data.wipe_hourly();
 DROP PROCEDURE IF EXISTS data.wipe_events();

--- a/prophesizer/migrations/R__2_ Create_Procedures.pgsql
+++ b/prophesizer/migrations/R__2_ Create_Procedures.pgsql
@@ -1,4 +1,4 @@
--- LAST UPDATE: 6/16/2021
+-- LAST UPDATE: 6/25/2021
  
 DROP PROCEDURE IF EXISTS data.wipe_hourly();
 DROP PROCEDURE IF EXISTS data.wipe_events();

--- a/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
+++ b/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
@@ -1,4 +1,6 @@
--- LAST UPDATE: 6/16/2021:
+-- LAST UPDATE: 6/25/2021:
+-- adding taxa.team_url_slugs (for Artists/Crabs)
+-- adding current_team_status column for taxa.team_additional_info (deal with deceased vs disbanded vs tournament)
 
 DROP TABLE IF EXISTS taxa.weather CASCADE;
 DROP SEQUENCE IF EXISTS taxa.vibe_to_arrows_vibe_to_arrow_id_seq CASCADE;
@@ -7,6 +9,7 @@ DROP SEQUENCE IF EXISTS taxa.team_divine_favor_team_divine_favor_id_seq CASCADE;
 DROP TABLE IF EXISTS taxa.team_divine_favor CASCADE;
 DROP SEQUENCE IF EXISTS taxa.team_abbreviations_team_abbreviation_id_seq CASCADE;
 DROP SEQUENCE IF EXISTS taxa.player_url_slugs_player_url_slug_id_seq CASCADE;
+DROP SEQUENCE IF EXISTS taxa.team_url_slugs_team_url_slug_id_seq CASCADE;
 DROP SEQUENCE IF EXISTS taxa.team_additional_info_team_additional_info_id_seq CASCADE;
 DROP TABLE IF EXISTS taxa.pitch_types CASCADE;
 DROP TABLE IF EXISTS taxa.phases CASCADE;
@@ -21,6 +24,7 @@ DROP SEQUENCE IF EXISTS taxa.attributes_attribute_id_seq CASCADE;
 DROP TABLE IF EXISTS taxa.attributes CASCADE;
 DROP TABLE IF EXISTS taxa.additional_info CASCADE;
 DROP TABLE IF EXISTS taxa.player_url_slugs CASCADE;
+DROP TABLE IF EXISTS taxa.team_url_slugs CASCADE;
 DROP TABLE IF EXISTS taxa.position_types CASCADE;
 DROP TABLE IF EXISTS taxa.coffee CASCADE;
 DROP TABLE IF EXISTS taxa.blood CASCADE;
@@ -107,7 +111,8 @@ CREATE TABLE taxa.team_abbreviations (
 CREATE TABLE taxa.team_additional_info (
 	team_additional_info_id INTEGER NOT NULL,
 	team_id character varying,
-	team_abbreviation character varying
+	team_abbreviation character varying,
+	team_current_status character varying
 );
 --
 -- Name: team_abbreviations_team_abbreviation_id_seq; Type: SEQUENCE; Schema: taxa; Owner: -
@@ -153,6 +158,16 @@ CREATE TABLE taxa.player_url_slugs (
     player_id character varying,
     url_slug character varying,
     player_name character varying
+);
+
+--
+-- Name: team_url_slugs; Type: TABLE; Schema: taxa; Owner: -
+--
+CREATE TABLE taxa.team_url_slugs (
+	team_url_slug_id SERIAL,
+	team_id VARCHAR NULL DEFAULT NULL,
+	url_slug VARCHAR NULL DEFAULT NULL,
+	team_name VARCHAR NULL DEFAULT NULL
 );
 
 --
@@ -1009,49 +1024,54 @@ VALUES
 
 INSERT INTO taxa.team_additional_info
 VALUES 
-(1,'8d87c468-699a-47a8-b40d-cfb73a5660ad','CRAB'),
-(2,'c73b705c-40ad-4633-a6ed-d357ee2e2bcf','LIFT'),
-(3,'878c1bf6-0d21-4659-bfee-916c8314d69c','TACO'),
-(4,'7fcb63bc-11f2-40b9-b465-f1d458692a63',NULL),
-(5,'e3f90fa1-0bbe-40df-88ce-578d0723a23b',NULL),
-(6,'a3ea6358-ce03-4f23-85f9-deb38cb81b20',NULL),
-(7,'f29d6e60-8fce-4ac6-8bc2-b5e3cabc5696',NULL),
-(8,'b63be8c2-576a-4d6e-8daf-814f8bcea96f','DALE'),
-(9,'3f8bbb15-61c0-4e3f-8e4a-907a5fb1565e','BOS'),
-(10,'36569151-a2fb-43c1-9df7-2df512424c82','NYM'),
-(11,'eb67ae5e-c4bf-46ca-bbbc-425cd34182ff','CAN'),
-(12,'49181b72-7f1c-4f1c-929f-928d763ad7fb',NULL),
-(13,'4d921519-410b-41e2-882e-9726a4e54a6a',NULL),
-(14,'bfd38797-8404-4b38-8b82-341da28b1f83','CHST'),
-(15,'7966eb04-efcc-499b-8f03-d13916330531','YELL'),
-(16,'9a5ab308-41f2-4889-a3c3-733b9aab806e',NULL),
-(17,'b3b9636a-f88a-47dc-a91d-86ecc79f9934',NULL),
-(18,'3b0a289b-aebd-493c-bc11-96793e7216d5',NULL),
-(19,'d2634113-b650-47b9-ad95-673f8e28e687',NULL),
-(20,'b024e975-1c4a-4575-8936-a3754a08806a','STK'),
-(21,'b72f3061-f573-40d7-832a-5ad475bd7909','LVRS'),
-(22,'979aee4a-6d80-4863-bf1c-ee1a78e06024','FRI'),
-(23,'d8f82163-2e74-496b-8e4b-2ab35b2d3ff1',NULL),
-(24,'a7592bd7-1d3c-4ffb-8b3a-0b1e4bc321fd',NULL),
-(25,'9e42c12a-7561-42a2-b2d0-7cf81a817a5e',NULL),
-(26,'70eab4ab-6cb1-41e7-ac8b-1050ee12eecc',NULL),
-(27,'4e5d0063-73b4-440a-b2d1-214a7345cf16',NULL),
-(28,'e8f7ffee-ec53-4fe0-8e87-ea8ff1d0b4a9',NULL),
-(29,'23e4cbc1-e9cd-47fa-a35b-bfa06f726cb7','PIES'),
-(30,'105bc3ff-1320-4e37-8ef0-8d595cb95dd0','SEA'),
-(31,'a37f9158-7f82-46bc-908c-c9e2dda7c33b','JAZZ'),
-(32,'f02aeae2-5e6a-4098-9842-02d2273f25c7','HELL'),
-(33,'ca3f1c8c-c025-4d8e-8eef-5be6accbeb16','CHI'),
-(34,'c6c01051-cdd4-47d6-8a98-bb5b754f937f','STAR'),
-(35,'adc5b394-8f76-416d-9ce9-813706877b84','KCBM'),
-(36,'747b8e4a-7e50-4638-a973-ea7950a3e739','TGRS'),
-(37,'9debc64f-74b7-4ae1-a4d6-fce0144b6ea5','SPY'),
-(38,'57ec08cc-0411-4643-b304-0e80dbc15ac7','CDMX'),
-(39,'40b9ec2a-cb43-4dbb-b836-5accb62e7c20','PODS'),
-(40,'bb4a9de5-c924-4923-a0cb-9d1445f1ee5d','OHWO'),
-(41,'46358869-dce9-4a01-bfba-ac24fc56f57e','CORE'),
-(42,'d9f89a8a-c563-493e-9d64-78e4f9a55d4a','ATL');
-
+(1,'8d87c468-699a-47a8-b40d-cfb73a5660ad','CRAB','active'),
+(2,'c73b705c-40ad-4633-a6ed-d357ee2e2bcf','LIFT','active'),
+(3,'878c1bf6-0d21-4659-bfee-916c8314d69c','TACO','active'),
+(4,'7fcb63bc-11f2-40b9-b465-f1d458692a63',NULL,'tournament'),
+(5,'e3f90fa1-0bbe-40df-88ce-578d0723a23b',NULL,'tournament'),
+(6,'a3ea6358-ce03-4f23-85f9-deb38cb81b20',NULL,'tournament'),
+(7,'f29d6e60-8fce-4ac6-8bc2-b5e3cabc5696',NULL,'tournament'),
+(8,'b63be8c2-576a-4d6e-8daf-814f8bcea96f','DALE','active'),
+(9,'3f8bbb15-61c0-4e3f-8e4a-907a5fb1565e','BOS','active'),
+(10,'36569151-a2fb-43c1-9df7-2df512424c82','NYM','active'),
+(11,'eb67ae5e-c4bf-46ca-bbbc-425cd34182ff','CAN','active'),
+(12,'49181b72-7f1c-4f1c-929f-928d763ad7fb',NULL,'tournament'),
+(13,'4d921519-410b-41e2-882e-9726a4e54a6a',NULL,'tournament'),
+(14,'bfd38797-8404-4b38-8b82-341da28b1f83','CHST','active'),
+(15,'7966eb04-efcc-499b-8f03-d13916330531','YELL','active'),
+(16,'9a5ab308-41f2-4889-a3c3-733b9aab806e',NULL,'tournament'),
+(17,'b3b9636a-f88a-47dc-a91d-86ecc79f9934',NULL,'tournament'),
+(18,'3b0a289b-aebd-493c-bc11-96793e7216d5',NULL,'tournament'),
+(19,'d2634113-b650-47b9-ad95-673f8e28e687',NULL,'tournament'),
+(20,'b024e975-1c4a-4575-8936-a3754a08806a','STK','active'),
+(21,'b72f3061-f573-40d7-832a-5ad475bd7909','LVRS','active'),
+(22,'979aee4a-6d80-4863-bf1c-ee1a78e06024','FRI','active'),
+(23,'d8f82163-2e74-496b-8e4b-2ab35b2d3ff1',NULL,'tournament'),
+(24,'a7592bd7-1d3c-4ffb-8b3a-0b1e4bc321fd',NULL,'tournament'),
+(25,'9e42c12a-7561-42a2-b2d0-7cf81a817a5e',NULL,'tournament'),
+(26,'70eab4ab-6cb1-41e7-ac8b-1050ee12eecc',NULL,'tournament'),
+(27,'4e5d0063-73b4-440a-b2d1-214a7345cf16',NULL,'tournament'),
+(28,'e8f7ffee-ec53-4fe0-8e87-ea8ff1d0b4a9',NULL,'tournament'),
+(29,'23e4cbc1-e9cd-47fa-a35b-bfa06f726cb7','PIES','active'),
+(30,'105bc3ff-1320-4e37-8ef0-8d595cb95dd0','SEA','active'),
+(31,'a37f9158-7f82-46bc-908c-c9e2dda7c33b','JAZZ','active'),
+(32,'f02aeae2-5e6a-4098-9842-02d2273f25c7','HELL','active'),
+(33,'ca3f1c8c-c025-4d8e-8eef-5be6accbeb16','CHI','active'),
+(34,'c6c01051-cdd4-47d6-8a98-bb5b754f937f','STAR','disbanded'),
+(35,'adc5b394-8f76-416d-9ce9-813706877b84','KCBM','active'),
+(36,'747b8e4a-7e50-4638-a973-ea7950a3e739','TGRS','active'),
+(37,'9debc64f-74b7-4ae1-a4d6-fce0144b6ea5','SPY','active'),
+(38,'57ec08cc-0411-4643-b304-0e80dbc15ac7','CDMX','active'),
+(39,'40b9ec2a-cb43-4dbb-b836-5accb62e7c20','PODS','disbanded'),
+(40,'bb4a9de5-c924-4923-a0cb-9d1445f1ee5d','OHWO','active'),
+(41,'46358869-dce9-4a01-bfba-ac24fc56f57e','CORE','active'),
+(42,'d9f89a8a-c563-493e-9d64-78e4f9a55d4a','ATL','active'),
+(43,'d6a352fc-b675-40a0-864d-f4fd50aaeea0','CART','deceased'),
+(44,'9494152b-99f6-4adb-9573-f9e084bc813f','CLAB','deceased'),
+(45,'71c621eb-85dc-4bd7-a690-0c68c0e6fb90','DOG','disbanded'),
+(46,'54d0d0f2-16e0-42a0-9fff-79cfa7c4a157','SK8','deceased'),
+(47,'88151292-6c12-4fb8-b2d6-3e64821293b3','AL8','deceased'),
+(48,'a4b23784-0132-4813-b300-f7449cb06493','TRNK','disbanded');
 --
 -- Data for Name: team_divine_favor; Type: TABLE DATA; Schema: taxa; Owner: -
 --

--- a/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
+++ b/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
@@ -1,6 +1,7 @@
--- LAST UPDATE: 6/25/2021
+-- LAST UPDATE: 6/28/2021:x
 -- adding taxa.team_url_slugs (for Artists/Crabs)
 -- adding current_team_status column for taxa.team_additional_info (deal with deceased vs disbanded vs tournament)
+-- adding additional weathers in taxa
 
 DROP TABLE IF EXISTS taxa.weather CASCADE;
 DROP SEQUENCE IF EXISTS taxa.vibe_to_arrows_vibe_to_arrow_id_seq CASCADE;
@@ -1230,7 +1231,15 @@ VALUES
 (16, 'Coffee 2'),
 (17, 'Coffee 3s'),
 (18, 'Flooding'),
-(19, 'Salmon');
+(19, 'Salmon'),
+(20, 'Polarity +'),
+(21, 'Polarity -'),
+(22, '???'),
+(23, 'Sun 90'),
+(24, 'Sun .1'),
+(25, 'Sum Sun'),
+(26, 'Jazz'),
+(27, 'Night');
 
 --
 -- Name: attributes attributes_pkey; Type: CONSTRAINT; Schema: taxa; Owner: -

--- a/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
+++ b/prophesizer/migrations/R__3_Create_And_Populate_Taxa.pgsql
@@ -1,4 +1,4 @@
--- LAST UPDATE: 6/25/2021:
+-- LAST UPDATE: 6/25/2021
 -- adding taxa.team_url_slugs (for Artists/Crabs)
 -- adding current_team_status column for taxa.team_additional_info (deal with deceased vs disbanded vs tournament)
 
@@ -1071,7 +1071,9 @@ VALUES
 (45,'71c621eb-85dc-4bd7-a690-0c68c0e6fb90','DOG','disbanded'),
 (46,'54d0d0f2-16e0-42a0-9fff-79cfa7c4a157','SK8','deceased'),
 (47,'88151292-6c12-4fb8-b2d6-3e64821293b3','AL8','deceased'),
-(48,'a4b23784-0132-4813-b300-f7449cb06493','TRNK','disbanded');
+(48,'a4b23784-0132-4813-b300-f7449cb06493','TRNK','disbanded'),
+(49,'c4f4115f-8856-a0c4-8a65-6a9ed046f509','TRK','deceased'),
+(50,'2a62cb4a-b56f-2a2f-9232-21c7bf2f3ffe','SK8','disbanded');
 --
 -- Data for Name: team_divine_favor; Type: TABLE DATA; Schema: taxa; Owner: -
 --

--- a/prophesizer/migrations/R__4_Create_Views.pgsql
+++ b/prophesizer/migrations/R__4_Create_Views.pgsql
@@ -1,5 +1,5 @@
--- LAST UPDATE: 6/16/2021:
--- player_status deal with active/shadow Cup issue, expanded on other statuses
+-- LAST UPDATE: 6/25/2021:
+-- teams_info_expanded_all now pulling team_current_status from taxa.team_additional_info
 
 DROP VIEW IF EXISTS DATA.team_seasonal_standings CASCADE;
 DROP VIEW IF EXISTS DATA.ref_leaderboard_lifetime_batting CASCADE;
@@ -250,18 +250,7 @@ t.nickname,
 t.full_name,
 ta.team_abbreviation,
 t.url_slug,
-CASE
-	WHEN EXISTS 
-	(
-		SELECT 1
-		FROM taxa.tournament_teams xtt
-		WHERE xtt.team_id = ts.team_id
-	) 
-	THEN 'tournament'
-	WHEN t.nickname IN ('PODS','Hall Stars')
-	THEN 'disbanded'
-   ELSE 'active'
-END AS current_team_status,
+ta.team_current_status,
 ts.timestampd AS valid_from,
 lead(ts.timestampd) OVER (PARTITION BY ts.team_id ORDER BY ts.timestampd) AS valid_until,
     ( SELECT gd1.gameday
@@ -789,7 +778,7 @@ CASE
 			SELECT 1
 			FROM data.team_roster rc
 			JOIN data.teams_info_expanded_all t ON (rc.team_id = t.team_id)
-			WHERE rc.player_id = p.player_id AND rc.valid_until IS NULL AND t.current_team_status = 'ascended'
+			WHERE rc.player_id = p.player_id AND rc.valid_until IS NULL AND t.team_current_status = 'ascended'
 			AND NOT EXISTS
 			(
 				SELECT 1
@@ -1230,7 +1219,7 @@ JOIN
 		rr.team_id = rt.team_id AND rt.valid_until IS NULL
 	)
 	WHERE rr.tournament > -1
-	and rt.current_team_status = 'tournament'
+	and rt.team_current_status = 'tournament'
 ) r ON 
 (
 	ts.player_id = r.player_id

--- a/prophesizer/migrations/R__4_Create_Views.pgsql
+++ b/prophesizer/migrations/R__4_Create_Views.pgsql
@@ -1,4 +1,4 @@
--- LAST UPDATE: 6/25/2021
+-- LAST UPDATE: 6/28/2021x
 -- teams_info_expanded_all now pulling team_current_status from taxa.team_additional_info
 
 DROP VIEW IF EXISTS DATA.team_seasonal_standings CASCADE;

--- a/prophesizer/migrations/R__4_Create_Views.pgsql
+++ b/prophesizer/migrations/R__4_Create_Views.pgsql
@@ -1,4 +1,4 @@
--- LAST UPDATE: 6/25/2021:
+-- LAST UPDATE: 6/25/2021
 -- teams_info_expanded_all now pulling team_current_status from taxa.team_additional_info
 
 DROP VIEW IF EXISTS DATA.team_seasonal_standings CASCADE;

--- a/prophesizer/migrations/R__5_Create_Comments.pgsql
+++ b/prophesizer/migrations/R__5_Create_Comments.pgsql
@@ -1,4 +1,4 @@
--- LAST UPDATE: 6/25/2021 
+-- LAST UPDATE: 6/28/2021x
 -- Changes to taxa.team_additional_info, taxa.team_url_slugs
 
 --Public schema

--- a/prophesizer/migrations/R__5_Create_Comments.pgsql
+++ b/prophesizer/migrations/R__5_Create_Comments.pgsql
@@ -1,4 +1,5 @@
--- LAST UPDATE: 6/16/2021 
+-- LAST UPDATE: 6/25/2021 
+-- Changes to taxa.team_additional_info, taxa.team_url_slugs
 
 --Public schema
 COMMENT ON table public.changelog IS 'Used by Prophesizer to keep track of versioining and migration scripts.  Should be truncated (As well as dropping data and taxa schemas) before a full database refresh.';
@@ -31,4 +32,5 @@ COMMENT ON table taxa.modifications IS 'Manually pulled on occasion from main.js
 COMMENT on table taxa.player_incinerations_unrecorded IS 'Manually input data for pre-dB player incinerations.';
 COMMENT ON table taxa.player_url_slugs IS 'Manually created unique player url slugs for initial Wyatt Masoning.';
 COMMENT ON table taxa.position_types IS 'Used to label position_type text on players_info_expanded_all.';
-COMMENT ON table taxa.team_additional_info IS 'Created by SIBR poll to teams.  Used to add team short name to teams_info_expanded_all.';
+COMMENT ON table taxa.team_additional_info IS 'Data currently not parseable by dB team object. Team short names created by SIBR poll to teams.  Last update: 6/25/2021';
+COMMENT ON table taxa.team_url_slugs IS 'Manually created to differentiate between multiple Artists/Crabs teams.  Last update: 6/25/2021';

--- a/prophesizer/patch/tourney_shadows.sql
+++ b/prophesizer/patch/tourney_shadows.sql
@@ -1,6 +1,8 @@
 --tourney shadows
 --because of the change from bullpen/bench to shadows, Coffee Cup teams are creating new records on team_roster
 
+--NOTE: Made redundant by update to tourney_timestamps on 6/25.  I know it ain't great.  Can we remove this eventually?
+
 update DATA.team_roster
 SET tournament = 0
 where team_id IN (SELECT team_id FROM taxa.tournament_teams);

--- a/prophesizer/patch/tourney_timestamps.sql
+++ b/prophesizer/patch/tourney_timestamps.sql
@@ -2,6 +2,7 @@
 
 --
 --NOTE: UPDATED 3/9, so Season 12 can be out of the Tournament, curse you Past Me!
+--NOTE: UPDATED AGAIN 6/25, the change to Shadows is bringing Cup Shadows players back out again.
 --
 /*
 DELETE FROM data.time_map WHERE first_time in ('2020-12-18 02:05:34.411348','2020-11-16 17:22:13.099255');
@@ -21,7 +22,7 @@ UPDATE data.team_roster SET tournament = -1;
 
 UPDATE data.players SET tournament = 0 WHERE valid_from BETWEEN '2020-11-16 17:00:00' AND '2021-03-01' OR valid_until BETWEEN '2020-11-16 17:00:00' AND '2021-03-01';
 UPDATE data.player_modifications SET tournament = 0 WHERE valid_from BETWEEN '2020-11-16 17:00:00' AND '2021-03-01' OR valid_until BETWEEN '2020-11-16 17:00:00' AND '2021-03-01';
-UPDATE data.team_roster SET tournament = 0 WHERE valid_from BETWEEN '2020-11-16 17:15:00' AND '2021-03-01' OR valid_until BETWEEN '2020-11-16 17:00:00' AND '2021-03-01';
+update DATA.team_roster SET tournament = 0 where team_id IN (SELECT team_id FROM taxa.tournament_teams); --6/25/2021
 
 --Specifically move Liquid and Uncle out of the Cup
 UPDATE data.players SET tournament = -1 WHERE player_id in ('d1a198d6-b05a-47cf-ab8e-39a6fa1ed831','fedbceb8-e2aa-4868-ac35-74cd0445893f');


### PR DESCRIPTION
Re-arranging tourney patches that are contradicting each other, 
updating team_current_status to reflect new pre-history team scenarios, 
crabs-2 & artists-2 slugs
other pre-history team fixes